### PR TITLE
feat: 태스크 생성, 조회 api 구현

### DIFF
--- a/team-taskflow/src/main/java/github/npcamp/teamtaskflow/domain/common/entity/Task.java
+++ b/team-taskflow/src/main/java/github/npcamp/teamtaskflow/domain/common/entity/Task.java
@@ -35,10 +35,9 @@ public class Task extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private TaskPriority priority;
 
-    // TODO : User 엔티티 추가 시 주석 해제
-//    @ManyToOne(fetch = FetchType.LAZY)
-//    @JoinColumn(name = "user_id")
-//    private User assignee;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User assignee;
 
     private LocalDateTime dueDate;
 

--- a/team-taskflow/src/main/java/github/npcamp/teamtaskflow/domain/task/controller/TaskController.java
+++ b/team-taskflow/src/main/java/github/npcamp/teamtaskflow/domain/task/controller/TaskController.java
@@ -1,4 +1,27 @@
 package github.npcamp.teamtaskflow.domain.task.controller;
 
+import github.npcamp.teamtaskflow.domain.task.dto.CreateTaskRequestDto;
+import github.npcamp.teamtaskflow.domain.task.dto.CreateTaskResponseDto;
+import github.npcamp.teamtaskflow.domain.task.service.TaskService;
+import github.npcamp.teamtaskflow.global.payload.ApiResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/tasks")
+@RequiredArgsConstructor
 public class TaskController {
+
+    private final TaskService taskService;
+
+    @PostMapping
+    public ResponseEntity<ApiResponse<CreateTaskResponseDto>> createTask(@Valid @RequestBody CreateTaskRequestDto req) {
+        CreateTaskResponseDto res = taskService.createTask(req);
+        return ResponseEntity.ok(ApiResponse.success(res));
+    }
 }

--- a/team-taskflow/src/main/java/github/npcamp/teamtaskflow/domain/task/controller/TaskController.java
+++ b/team-taskflow/src/main/java/github/npcamp/teamtaskflow/domain/task/controller/TaskController.java
@@ -2,15 +2,19 @@ package github.npcamp.teamtaskflow.domain.task.controller;
 
 import github.npcamp.teamtaskflow.domain.task.dto.CreateTaskRequestDto;
 import github.npcamp.teamtaskflow.domain.task.dto.CreateTaskResponseDto;
+import github.npcamp.teamtaskflow.domain.task.dto.TaskResponseDto;
+import github.npcamp.teamtaskflow.domain.task.dto.TaskDetailResponseDto;
 import github.npcamp.teamtaskflow.domain.task.service.TaskService;
 import github.npcamp.teamtaskflow.global.payload.ApiResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/tasks")
@@ -22,6 +26,18 @@ public class TaskController {
     @PostMapping
     public ResponseEntity<ApiResponse<CreateTaskResponseDto>> createTask(@Valid @RequestBody CreateTaskRequestDto req) {
         CreateTaskResponseDto res = taskService.createTask(req);
-        return ResponseEntity.ok(ApiResponse.success(res));
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(res));
+    }
+
+    @GetMapping("/{taskId}")
+    public ResponseEntity<ApiResponse<TaskDetailResponseDto>> getTask(@PathVariable Long taskId) {
+        TaskDetailResponseDto res = taskService.getTask(taskId);
+        return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.success(res));
+    }
+
+    @GetMapping
+    public ResponseEntity<ApiResponse<Page<TaskResponseDto>>> getTasks(@PageableDefault(sort = "dueDate", direction = Sort.Direction.DESC) Pageable pageable) {
+        Page<TaskResponseDto> tasks = taskService.getTasks(pageable);
+        return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.success(tasks));
     }
 }

--- a/team-taskflow/src/main/java/github/npcamp/teamtaskflow/domain/task/dto/CreateTaskDto.java
+++ b/team-taskflow/src/main/java/github/npcamp/teamtaskflow/domain/task/dto/CreateTaskDto.java
@@ -1,4 +1,0 @@
-package github.npcamp.teamtaskflow.domain.task.dto;
-
-public class CreateTaskDto {
-}

--- a/team-taskflow/src/main/java/github/npcamp/teamtaskflow/domain/task/dto/CreateTaskRequestDto.java
+++ b/team-taskflow/src/main/java/github/npcamp/teamtaskflow/domain/task/dto/CreateTaskRequestDto.java
@@ -1,0 +1,31 @@
+package github.npcamp.teamtaskflow.domain.task.dto;
+
+import github.npcamp.teamtaskflow.domain.task.TaskPriority;
+import jakarta.validation.constraints.Future;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+public class CreateTaskRequestDto {
+
+    @NotBlank(message = "제목은 필수입니다.")
+    private final String title;
+
+    @NotBlank(message = "내용은 필수입니다.")
+    private final String content;
+
+    @NotNull(message = "우선순위는 필수입니다.")
+    private final TaskPriority priority; // Enum 타입으로 명확히 정의
+
+    @NotNull(message = "담당자 ID는 필수입니다.")
+    private final Long assigneeId;
+
+    @NotNull(message = "마감일은 필수입니다.")
+    @Future(message = "마감일은 현재 시간보다 이후여야 합니다.")
+    private final LocalDateTime dueDate;
+}

--- a/team-taskflow/src/main/java/github/npcamp/teamtaskflow/domain/task/dto/CreateTaskResponseDto.java
+++ b/team-taskflow/src/main/java/github/npcamp/teamtaskflow/domain/task/dto/CreateTaskResponseDto.java
@@ -1,0 +1,39 @@
+package github.npcamp.teamtaskflow.domain.task.dto;
+
+import github.npcamp.teamtaskflow.domain.common.entity.Task;
+import github.npcamp.teamtaskflow.domain.task.TaskPriority;
+import github.npcamp.teamtaskflow.domain.task.TaskStatus;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class CreateTaskResponseDto {
+
+    private final Long id;
+    private final String title;
+    private final String content;
+    private final TaskPriority priority;
+    private final TaskStatus status;
+    private final String assignee;
+    private final LocalDateTime dueDate;
+    private final LocalDateTime createdAt;
+
+    public static CreateTaskResponseDto toDto(Task task) {
+        return CreateTaskResponseDto.builder()
+                .id(task.getId())
+                .title(task.getTitle())
+                .content(task.getContent())
+                .priority(task.getPriority())
+                .status(task.getStatus())
+                .assignee(task.getAssignee().getUsername())
+                .dueDate(task.getDueDate())
+                .createdAt(task.getCreatedAt())
+                .build();
+    }
+
+}

--- a/team-taskflow/src/main/java/github/npcamp/teamtaskflow/domain/task/dto/TaskDetailResponseDto.java
+++ b/team-taskflow/src/main/java/github/npcamp/teamtaskflow/domain/task/dto/TaskDetailResponseDto.java
@@ -23,9 +23,7 @@ public class TaskDetailResponseDto {
     private final LocalDateTime dueDate;
     private final LocalDateTime createdAt;
     private final LocalDateTime updatedAt;
-//    private final List<CommentResponseDto> comments; TODO
 
-    //    public static TaskResponseDto toDto(Task task, List<CommentResponseDto> comments)
     public static TaskDetailResponseDto toDto(Task task) {
         return TaskDetailResponseDto.builder()
                 .id(task.getId())
@@ -37,7 +35,6 @@ public class TaskDetailResponseDto {
                 .dueDate(task.getDueDate())
                 .createdAt(task.getCreatedAt())
                 .updatedAt(task.getUpdatedAt())
-//                .comments(comments) TODO
                 .build();
     }
 

--- a/team-taskflow/src/main/java/github/npcamp/teamtaskflow/domain/task/dto/TaskDetailResponseDto.java
+++ b/team-taskflow/src/main/java/github/npcamp/teamtaskflow/domain/task/dto/TaskDetailResponseDto.java
@@ -1,0 +1,45 @@
+package github.npcamp.teamtaskflow.domain.task.dto;
+
+import github.npcamp.teamtaskflow.domain.common.entity.Task;
+import github.npcamp.teamtaskflow.domain.task.TaskPriority;
+import github.npcamp.teamtaskflow.domain.task.TaskStatus;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class TaskDetailResponseDto {
+
+    private final Long id;
+    private final String title;
+    private final String content;
+    private final TaskPriority priority;
+    private final TaskStatus status;
+    private final String assignee;
+    private final LocalDateTime dueDate;
+    private final LocalDateTime createdAt;
+    private final LocalDateTime updatedAt;
+//    private final List<CommentResponseDto> comments; TODO
+
+    //    public static TaskResponseDto toDto(Task task, List<CommentResponseDto> comments)
+    public static TaskDetailResponseDto toDto(Task task) {
+        return TaskDetailResponseDto.builder()
+                .id(task.getId())
+                .title(task.getTitle())
+                .content(task.getContent())
+                .priority(task.getPriority())
+                .status(task.getStatus())
+                .assignee(task.getAssignee().getUsername())
+                .dueDate(task.getDueDate())
+                .createdAt(task.getCreatedAt())
+                .updatedAt(task.getUpdatedAt())
+//                .comments(comments) TODO
+                .build();
+    }
+
+
+}

--- a/team-taskflow/src/main/java/github/npcamp/teamtaskflow/domain/task/dto/TaskResponseDto.java
+++ b/team-taskflow/src/main/java/github/npcamp/teamtaskflow/domain/task/dto/TaskResponseDto.java
@@ -1,0 +1,34 @@
+package github.npcamp.teamtaskflow.domain.task.dto;
+
+
+import github.npcamp.teamtaskflow.domain.common.entity.Task;
+import github.npcamp.teamtaskflow.domain.task.TaskPriority;
+import github.npcamp.teamtaskflow.domain.task.TaskStatus;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class TaskResponseDto {
+
+    private final Long id;
+    private final String title;
+    private final TaskPriority priority;
+    private final TaskStatus status;
+    private final LocalDateTime dueDate;
+
+    public static TaskResponseDto toDto(Task task) {
+        return TaskResponseDto.builder()
+                .id(task.getId())
+                .title(task.getTitle())
+                .priority(task.getPriority())
+                .status(task.getStatus())
+                .dueDate(task.getDueDate())
+                .build();
+    }
+
+}

--- a/team-taskflow/src/main/java/github/npcamp/teamtaskflow/domain/task/repository/TaskRepository.java
+++ b/team-taskflow/src/main/java/github/npcamp/teamtaskflow/domain/task/repository/TaskRepository.java
@@ -1,4 +1,7 @@
 package github.npcamp.teamtaskflow.domain.task.repository;
 
-public interface TaskRepository {
+import github.npcamp.teamtaskflow.domain.common.entity.Task;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TaskRepository extends JpaRepository<Task, Long> {
 }

--- a/team-taskflow/src/main/java/github/npcamp/teamtaskflow/domain/task/service/TaskService.java
+++ b/team-taskflow/src/main/java/github/npcamp/teamtaskflow/domain/task/service/TaskService.java
@@ -1,4 +1,8 @@
 package github.npcamp.teamtaskflow.domain.task.service;
 
+import github.npcamp.teamtaskflow.domain.task.dto.CreateTaskRequestDto;
+import github.npcamp.teamtaskflow.domain.task.dto.CreateTaskResponseDto;
+
 public interface TaskService {
+    CreateTaskResponseDto createTask(CreateTaskRequestDto req);
 }

--- a/team-taskflow/src/main/java/github/npcamp/teamtaskflow/domain/task/service/TaskService.java
+++ b/team-taskflow/src/main/java/github/npcamp/teamtaskflow/domain/task/service/TaskService.java
@@ -2,7 +2,16 @@ package github.npcamp.teamtaskflow.domain.task.service;
 
 import github.npcamp.teamtaskflow.domain.task.dto.CreateTaskRequestDto;
 import github.npcamp.teamtaskflow.domain.task.dto.CreateTaskResponseDto;
+import github.npcamp.teamtaskflow.domain.task.dto.TaskResponseDto;
+import github.npcamp.teamtaskflow.domain.task.dto.TaskDetailResponseDto;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 public interface TaskService {
+
     CreateTaskResponseDto createTask(CreateTaskRequestDto req);
+
+    TaskDetailResponseDto getTask(Long taskId);
+
+    Page<TaskResponseDto> getTasks(Pageable pageable);
 }

--- a/team-taskflow/src/main/java/github/npcamp/teamtaskflow/domain/task/service/TaskServiceImpl.java
+++ b/team-taskflow/src/main/java/github/npcamp/teamtaskflow/domain/task/service/TaskServiceImpl.java
@@ -3,19 +3,31 @@ package github.npcamp.teamtaskflow.domain.task.service;
 import github.npcamp.teamtaskflow.domain.common.entity.Task;
 import github.npcamp.teamtaskflow.domain.task.dto.CreateTaskRequestDto;
 import github.npcamp.teamtaskflow.domain.task.dto.CreateTaskResponseDto;
+import github.npcamp.teamtaskflow.domain.task.dto.TaskResponseDto;
+import github.npcamp.teamtaskflow.domain.task.dto.TaskDetailResponseDto;
+import github.npcamp.teamtaskflow.domain.task.exception.TaskNotFoundException;
 import github.npcamp.teamtaskflow.domain.task.repository.TaskRepository;
+import github.npcamp.teamtaskflow.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 public class TaskServiceImpl implements TaskService {
 
     private final TaskRepository taskRepository;
-//    private final UserService userService;
+//    private final UserService userService; TODO
+//    private final CommentService commentService; TODO
 //    private final ActivityLogService activityLogService; TODO
 
+    /**
+     * Task 생성
+     */
     @Override
+    @Transactional
     public CreateTaskResponseDto createTask(CreateTaskRequestDto req) {
 
 //        User assignee = userService.findById(req.getAssigneeId()); TODO
@@ -31,5 +43,31 @@ public class TaskServiceImpl implements TaskService {
         Task savedTask = taskRepository.save(task);
 
         return CreateTaskResponseDto.toDto(savedTask);
+    }
+
+    /**
+     * Task 단건과 댓글 목록을 조회
+     */
+    @Override
+    @Transactional(readOnly = true)
+    public TaskDetailResponseDto getTask(Long taskId) {
+
+        Task task = taskRepository.findById(taskId)
+                .orElseThrow(() -> new TaskNotFoundException(ErrorCode.TASK_NOT_FOUND));
+
+        // taskId로 커멘트 리스트를 찾아오기 TODO
+
+//        return TaskResponseDto.toDto(task, comments); TODO
+        return TaskDetailResponseDto.toDto(task);
+    }
+
+    /**
+     * Task page조회 defalut size = 10
+     */
+    @Override
+    @Transactional(readOnly = true)
+    public Page<TaskResponseDto> getTasks(Pageable pageable) {
+        Page<Task> tasks = taskRepository.findAll(pageable);
+        return tasks.map(TaskResponseDto::toDto);
     }
 }

--- a/team-taskflow/src/main/java/github/npcamp/teamtaskflow/domain/task/service/TaskServiceImpl.java
+++ b/team-taskflow/src/main/java/github/npcamp/teamtaskflow/domain/task/service/TaskServiceImpl.java
@@ -1,4 +1,35 @@
 package github.npcamp.teamtaskflow.domain.task.service;
 
+import github.npcamp.teamtaskflow.domain.common.entity.Task;
+import github.npcamp.teamtaskflow.domain.task.dto.CreateTaskRequestDto;
+import github.npcamp.teamtaskflow.domain.task.dto.CreateTaskResponseDto;
+import github.npcamp.teamtaskflow.domain.task.repository.TaskRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
 public class TaskServiceImpl implements TaskService {
+
+    private final TaskRepository taskRepository;
+//    private final UserService userService;
+//    private final ActivityLogService activityLogService; TODO
+
+    @Override
+    public CreateTaskResponseDto createTask(CreateTaskRequestDto req) {
+
+//        User assignee = userService.findById(req.getAssigneeId()); TODO
+
+        Task task = Task.builder()
+                .title(req.getTitle())
+                .content(req.getContent())
+                .priority(req.getPriority())
+//                .assignee(assignee) TODO
+                .dueDate(req.getDueDate())
+                .build();
+
+        Task savedTask = taskRepository.save(task);
+
+        return CreateTaskResponseDto.toDto(savedTask);
+    }
 }

--- a/team-taskflow/src/main/java/github/npcamp/teamtaskflow/domain/task/service/TaskServiceImpl.java
+++ b/team-taskflow/src/main/java/github/npcamp/teamtaskflow/domain/task/service/TaskServiceImpl.java
@@ -20,7 +20,6 @@ public class TaskServiceImpl implements TaskService {
 
     private final TaskRepository taskRepository;
 //    private final UserService userService; TODO
-//    private final CommentService commentService; TODO
 //    private final ActivityLogService activityLogService; TODO
 
     /**
@@ -55,9 +54,6 @@ public class TaskServiceImpl implements TaskService {
         Task task = taskRepository.findById(taskId)
                 .orElseThrow(() -> new TaskNotFoundException(ErrorCode.TASK_NOT_FOUND));
 
-        // taskId로 커멘트 리스트를 찾아오기 TODO
-
-//        return TaskResponseDto.toDto(task, comments); TODO
         return TaskDetailResponseDto.toDto(task);
     }
 

--- a/team-taskflow/src/main/java/github/npcamp/teamtaskflow/global/exception/GlobalExceptionHandler.java
+++ b/team-taskflow/src/main/java/github/npcamp/teamtaskflow/global/exception/GlobalExceptionHandler.java
@@ -1,10 +1,34 @@
 package github.npcamp.teamtaskflow.global.exception;
+
 import github.npcamp.teamtaskflow.global.payload.ApiResponse;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
 
+import java.util.HashMap;
+import java.util.Map;
+
+@RestControllerAdvice
 public class GlobalExceptionHandler {
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ApiResponse<Map<String, String>>> handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
+
+        Map<String, String> errors = new HashMap<>();
+        e.getBindingResult().getFieldErrors().forEach(error -> {
+            errors.put(error.getField(), error.getDefaultMessage());
+        });
+
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(ApiResponse.failure(errors));
+    }
+
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public ResponseEntity<ApiResponse<Void>> handleHttpMessageNotReadableException(HttpMessageNotReadableException e) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(ApiResponse.failure("요청 데이터의 타입이 올바르지 않습니다."));
+    }
 
     @ExceptionHandler(CustomException.class)
     protected ResponseEntity<ApiResponse<Void>> handleCustomException(CustomException e) {

--- a/team-taskflow/src/main/java/github/npcamp/teamtaskflow/global/payload/ApiResponse.java
+++ b/team-taskflow/src/main/java/github/npcamp/teamtaskflow/global/payload/ApiResponse.java
@@ -5,6 +5,8 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.Setter;
 
+import java.time.LocalDateTime;
+
 @Getter
 @Setter
 @AllArgsConstructor
@@ -12,30 +14,31 @@ public class ApiResponse<T> {
 
     private final boolean success;
     private final String message;
+    private final LocalDateTime timestamp;
     private final T data;
 
     public static <T> ApiResponse<T> success(T data) {
-        return new ApiResponse<>(true, "요청이 성공했습니다.", data);
+        return new ApiResponse<>(true, "요청이 성공했습니다.", LocalDateTime.now(), data);
     }
 
     public static <T> ApiResponse<T> success(String message, T data) {
-        return new ApiResponse<>(true, message, data);
+        return new ApiResponse<>(true, message, LocalDateTime.now(), data);
     }
 
     public static <T> ApiResponse<T> success(String message) {
-        return new ApiResponse<>(true, message, null);
+        return new ApiResponse<>(true, message, LocalDateTime.now(), null);
     }
 
     public static <T> ApiResponse<T> success() {
-        return new ApiResponse<>(true, "요청이 성공했습니다.", null);
+        return new ApiResponse<>(true, "요청이 성공했습니다.", LocalDateTime.now(), null);
     }
 
     public static <T> ApiResponse<T> failure(String message) {
-        return new ApiResponse<>(false, message, null);
+        return new ApiResponse<>(false, message, LocalDateTime.now(), null);
     }
 
     public static <T> ApiResponse<T> failure(T data) {
-        return new ApiResponse<>(false, "요청이 실패했습니다.", data);
+        return new ApiResponse<>(false, "요청이 실패했습니다.", LocalDateTime.now(), data);
     }
 
 }

--- a/team-taskflow/src/main/java/github/npcamp/teamtaskflow/global/payload/ApiResponse.java
+++ b/team-taskflow/src/main/java/github/npcamp/teamtaskflow/global/payload/ApiResponse.java
@@ -34,5 +34,9 @@ public class ApiResponse<T> {
         return new ApiResponse<>(false, message, null);
     }
 
+    public static <T> ApiResponse<T> failure(T data) {
+        return new ApiResponse<>(false, "요청이 실패했습니다.", data);
+    }
+
 }
 

--- a/team-taskflow/src/test/java/github/npcamp/teamtaskflow/domain/task/service/TaskServiceImplTest.java
+++ b/team-taskflow/src/test/java/github/npcamp/teamtaskflow/domain/task/service/TaskServiceImplTest.java
@@ -1,0 +1,65 @@
+package github.npcamp.teamtaskflow.domain.task.service;
+
+import github.npcamp.teamtaskflow.domain.common.entity.Task;
+import github.npcamp.teamtaskflow.domain.common.entity.User;
+import github.npcamp.teamtaskflow.domain.task.TaskPriority;
+import github.npcamp.teamtaskflow.domain.task.dto.CreateTaskRequestDto;
+import github.npcamp.teamtaskflow.domain.task.dto.CreateTaskResponseDto;
+import github.npcamp.teamtaskflow.domain.task.repository.TaskRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.LocalDateTime;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class TaskServiceImplTest {
+
+    @InjectMocks
+    TaskServiceImpl taskService;
+
+    @Mock
+    TaskRepository taskRepository;
+
+    @Test
+    void 태스크_저장_서비스_단위_테스트() {
+
+        // given
+        CreateTaskRequestDto dto = new CreateTaskRequestDto("테스트 제목", "테스트 내용", TaskPriority.LOW, 1L, LocalDateTime.now().plusDays(1));
+
+        User user = mock();
+        ReflectionTestUtils.setField(user, "id", dto.getAssigneeId());
+        // TODO: 기존 서비스 로직 변경되면 추가로 변경
+
+        Task savedTask = Task.builder()
+                .title(dto.getTitle())
+                .content(dto.getContent())
+                .priority(dto.getPriority())
+                .assignee(user)
+                .dueDate(dto.getDueDate())
+                .build();
+
+        given(taskRepository.save(any(Task.class))).willReturn(savedTask);
+
+        // when
+        CreateTaskResponseDto responseDto = taskService.createTask(dto);
+
+        // then
+
+        // 상태검증
+        assertEquals(dto.getTitle(), responseDto.getTitle());
+        assertEquals(dto.getContent(), responseDto.getContent());
+        assertEquals(dto.getPriority(), responseDto.getPriority());
+        assertEquals(user.getUsername(), responseDto.getAssignee());
+        assertEquals(dto.getDueDate(), responseDto.getDueDate());
+    }
+
+}

--- a/team-taskflow/src/test/java/github/npcamp/teamtaskflow/domain/task/service/TaskServiceImplTest.java
+++ b/team-taskflow/src/test/java/github/npcamp/teamtaskflow/domain/task/service/TaskServiceImplTest.java
@@ -89,11 +89,9 @@ public class TaskServiceImplTest {
     void 태스크단건_조회실패() {
         // given
         long taskId = 1L;
-
-        // when
         given(taskRepository.findById(anyLong())).willReturn(null);
 
-        // then
+        // when & then
         assertThrows(NullPointerException.class, () -> taskService.getTask(taskId));
     }
 }

--- a/team-taskflow/src/test/java/github/npcamp/teamtaskflow/domain/task/service/TaskServiceImplTest.java
+++ b/team-taskflow/src/test/java/github/npcamp/teamtaskflow/domain/task/service/TaskServiceImplTest.java
@@ -5,6 +5,7 @@ import github.npcamp.teamtaskflow.domain.common.entity.User;
 import github.npcamp.teamtaskflow.domain.task.TaskPriority;
 import github.npcamp.teamtaskflow.domain.task.dto.CreateTaskRequestDto;
 import github.npcamp.teamtaskflow.domain.task.dto.CreateTaskResponseDto;
+import github.npcamp.teamtaskflow.domain.task.dto.TaskDetailResponseDto;
 import github.npcamp.teamtaskflow.domain.task.repository.TaskRepository;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -14,9 +15,11 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.time.LocalDateTime;
+import java.util.Optional;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.*;
 
@@ -37,7 +40,6 @@ public class TaskServiceImplTest {
 
         User user = mock();
         ReflectionTestUtils.setField(user, "id", dto.getAssigneeId());
-        // TODO: 기존 서비스 로직 변경되면 추가로 변경
 
         Task savedTask = Task.builder()
                 .title(dto.getTitle())
@@ -62,4 +64,36 @@ public class TaskServiceImplTest {
         assertEquals(dto.getDueDate(), responseDto.getDueDate());
     }
 
+    @Test
+    void 태스크단건_정상조회() {
+        // given
+        long taskId = 1L;
+
+        User user = mock();
+        ReflectionTestUtils.setField(user, "username", "테스트 이름");
+
+        Task task = Task.builder()
+                .assignee(user)
+                .build();
+
+        given(taskRepository.findById(anyLong())).willReturn(Optional.of(task));
+
+        // when
+        TaskDetailResponseDto res = taskService.getTask(taskId);
+
+        // then
+        assertNotNull(res);
+    }
+
+    @Test
+    void 태스크단건_조회실패() {
+        // given
+        long taskId = 1L;
+
+        // when
+        given(taskRepository.findById(anyLong())).willReturn(null);
+
+        // then
+        assertThrows(NullPointerException.class, () -> taskService.getTask(taskId));
+    }
 }


### PR DESCRIPTION
## 이슈 번호
#3
#4 
#6 

## 작업 내용
- @Valid 요청 검증 예외 처리 추가
- 데이터 타입 불일치로 인한 바인딩 실패 예외 처리 추가
- 공통 응답 객체 생성자 추가
### 태스크 생성
- 태스크 생성 요청, 응답 dto 생성
- 태스크 생성 3계층 구현
- 태스크 생성 테스트 코드 작성
### 태스크 조회
- 태스크 조회 요청,응답 dto 생성
- 태스크 조회 3계층 구현
- 태스크 조회 테스트 코드 작성

## 스크린샷(선택)
