### PR TITLE
Feat/log 댓글 활동 로그 API 구현

### DIFF
--- a/team-taskflow/src/main/java/github/npcamp/teamtaskflow/domain/comment/controller/CommentController.java
+++ b/team-taskflow/src/main/java/github/npcamp/teamtaskflow/domain/comment/controller/CommentController.java
@@ -6,6 +6,8 @@ import github.npcamp.teamtaskflow.domain.comment.dto.response.CommentDeleteRespo
 import github.npcamp.teamtaskflow.domain.comment.dto.response.CommentResponseDto;
 import github.npcamp.teamtaskflow.domain.comment.dto.response.CommentResponseListDto;
 import github.npcamp.teamtaskflow.domain.comment.service.CommentService;
+import github.npcamp.teamtaskflow.domain.common.aop.Logging;
+import github.npcamp.teamtaskflow.domain.log.ActivityType;
 import github.npcamp.teamtaskflow.global.payload.ApiResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -27,6 +29,7 @@ public class CommentController {
 
     //댓글생성
     @PostMapping
+    @Logging(ActivityType.COMMENT_CREATED)
     public ResponseEntity<ApiResponse<CommentResponseDto>> createComment(
             @PathVariable Long taskId,
             @Valid @RequestBody CreateCommentRequestDto requestDto,
@@ -48,6 +51,7 @@ public class CommentController {
 
     //댓글 수정 - content만 수정하므로, patch사용함.
     @PatchMapping("/{commentId}")
+    @Logging(ActivityType.COMMENT_UPDATED)
     public ResponseEntity<ApiResponse<CommentResponseDto>> updateComment(
             @PathVariable Long taskId,
             @PathVariable Long commentId,
@@ -60,6 +64,7 @@ public class CommentController {
 
     //댓글삭제 (soft delete)
     @DeleteMapping("/{commentId}")
+    @Logging(ActivityType.COMMENT_DELETED)
     public ResponseEntity<ApiResponse<CommentDeleteResponseDto>> deleteComment(
             @PathVariable Long taskId,
             @PathVariable Long commentId,

--- a/team-taskflow/src/main/java/github/npcamp/teamtaskflow/domain/comment/dto/response/CommentResponseDto.java
+++ b/team-taskflow/src/main/java/github/npcamp/teamtaskflow/domain/comment/dto/response/CommentResponseDto.java
@@ -1,5 +1,6 @@
 package github.npcamp.teamtaskflow.domain.comment.dto.response;
 
+import github.npcamp.teamtaskflow.domain.common.base.Identifiable;
 import github.npcamp.teamtaskflow.domain.common.entity.Comment;
 import lombok.Builder;
 
@@ -15,7 +16,8 @@ public record CommentResponseDto(
         LocalDateTime createdAt,
         LocalDateTime updatedAt,
         boolean isDeleted
-) {
+) implements Identifiable {
+
     public static CommentResponseDto toDto(Comment comment) {
         return CommentResponseDto.builder()
                 .id(comment.getId())
@@ -28,4 +30,11 @@ public record CommentResponseDto(
                 .isDeleted(comment.isDeleted())
                 .build();
     }
+
+    @Override
+    public Long getId() {
+        return this.id;
+    }
 }
+
+

--- a/team-taskflow/src/main/java/github/npcamp/teamtaskflow/domain/log/ActivityType.java
+++ b/team-taskflow/src/main/java/github/npcamp/teamtaskflow/domain/log/ActivityType.java
@@ -11,6 +11,7 @@ public enum ActivityType {
     TASK_DELETED("작업이 삭제되었습니다."),
     TASK_STATUS_CHANGED("작업 상태가 %s에서 %s(으)로 변경되었습니다."),
     COMMENT_CREATED("댓글이 작성되었습니다."),
+    COMMENT_UPDATED("댓글이 수정되었습니다."),
     COMMENT_DELETED("댓글이 삭제되었습니다."),
     USER_LOGGED_IN("로그인하였습니다."),
     USER_LOGGED_OUT("로그아웃하였습니다.");


### PR DESCRIPTION
## 이슈 번호
#49 

## 작업 내용
댓글 생성, 수정, 삭제 시 활동 로그 API 구현

## 스크린샷(선택)
